### PR TITLE
Added Kickoff Link

### DIFF
--- a/frclinks.py
+++ b/frclinks.py
@@ -442,6 +442,13 @@ class TIMSPage(webapp.RequestHandler):
   """
   def get(self):
     Redir(self, 'https://my.usfirst.org/frc/tims/site.lasso')
+
+class KickoffPage(webapp.RequestHandler):
+  """
+  Redirects the user to the FRC Kickoff Page from FIRST
+  """
+  def get(self):
+    Redir(self, frcUrl + 'kickoff')
     
 class CookiePage(webapp.RequestHandler):
   """
@@ -570,6 +577,8 @@ application = webapp.WSGIApplication([
     (r'/youtube/?', YouTubePage),
     (r'/y/?', YouTubePage),
     (r'/tims/?', TIMSPage),
+    (r'/kickoff/?', KickoffPage),
+    (r'/ko/?', KickoffPage),
     (r'/cookie/?', CookiePage),
     (r'/flushnewteams/?', FlushNewTeamsPage),
     (r'/flusholdteams/?', FlushOldTeamsPage),

--- a/templates/instructions.html
+++ b/templates/instructions.html
@@ -206,6 +206,12 @@ POSSIBILITY OF SUCH DAMAGE.
         <td>FRC TIMS login page. </td>
       </tr>
       <tr>
+        <td><b>/kickoff</b></td>
+        <td>/ko</td>
+        <td>&nbsp;</td>
+        <td>FRC Kickoff page.</td>
+      </tr>
+      <tr>
         <td><b>/youtube</b></td>
         <td><b>/y</b></td>
         <td>&nbsp;</td>


### PR DESCRIPTION
I added a link to send people to the FRC Kickoff page (frclinks.com/kickoff or frclinks.com/ko)

Hopefully once the URL for the stream this year is known it can be substituted in as a way for people to quickly find the webcast. Because I know I'm not the only one that has had to assist a technically inept parent trying to find the webcast via phone.

The <a href="http://robotics.nasa.gov/events/2012_kickoff.php">NASA page</a> for last year doesn't have any URL that looks promising as a base for next year's webcast link, and the 2013 page isn't up yet, or that probably would have been a better resource to link to.
